### PR TITLE
Returns no result for url string, missing "/"

### DIFF
--- a/src/QueryableModel.php
+++ b/src/QueryableModel.php
@@ -729,7 +729,11 @@ abstract class QueryableModel implements Arrayable, ArrayAccess, Jsonable, JsonS
    */
   public function resolveRouteBinding($value, $field = null)
   {
-    if ($model = static::where($field ?? $this->getResolvableField(), $value)->first()) {
+    $field = $field ?? $this->getResolvableField();
+    $operator = $field === $this->getKey() ? '=' : 'like';
+    $value = $operator === 'like' ? "*$value*" : $value;
+
+    if ($model = static::where($field, $operator, $value)->first()) {
       return $model;
     }
 


### PR DESCRIPTION
Fixes bug where searching for a entry by its url slug would return no results. This happens because the url slug is always appended by a "/", but resolveRouteBinding searches without.

This fix checks if its a url slug or ID thats being used in the search. And if it is a slug, then appends wildcard characters

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our [guidelines](COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
