### PR TITLE
Bugfixes in QueryBuilder and new cache functionality

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -14,7 +14,7 @@
   verbose="true"
 >
   <testsuites>
-    <testsuite name="Netflex QueruBuilder tests">
+    <testsuite name="Netflex QueryBuilder tests">
       <directory suffix=".test.php">
         tests
       </directory>

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -202,7 +202,7 @@ class Builder
    */
   protected function compileNullQuery($field)
   {
-    return "(NOT _exists_:{$field})";
+    return "((NOT _exists_:{$field}) OR {$field}:0)";
   }
 
   /**

--- a/src/QueryableModel.php
+++ b/src/QueryableModel.php
@@ -44,6 +44,14 @@ abstract class QueryableModel implements Arrayable, ArrayAccess, Jsonable, JsonS
   protected $perPage = 100;
 
   /**
+   * Determines if QueryableModel::all() calls in queries should chunk the result.
+   * NOTICE: If chunking is enabled, the results of QueryableModel::all() will not be cached, and can result in a performance hit on large structures.
+   *
+   * @var bool
+   */
+  protected $useChunking = false;
+
+  /**
    * Indicates if the model exists.
    *
    * @var bool

--- a/src/Traits/HasRelation.php
+++ b/src/Traits/HasRelation.php
@@ -2,6 +2,8 @@
 
 namespace Netflex\Query\Traits;
 
+use Illuminate\Support\Str;
+
 trait HasRelation
 {
   /**
@@ -28,6 +30,7 @@ trait HasRelation
    * Creates a cacheKey
    *
    * @param mixed $identifier
+   * @param string $prefix = null
    * @return string
    */
   protected function getCacheIdentifier($identifier = null)
@@ -37,6 +40,17 @@ trait HasRelation
 
     $cacheKey = array_filter([$relation, $relationId, $identifier]);
 
+    return implode('/', $cacheKey);
+  }
+
+  protected function getAllCacheIdentifier()
+  {
+    $relation = $this->getRelation();
+    $relation = $relation ? Str::plural($relation) : $relation;
+    $relationId = $this->getRelationId();
+
+    $cacheKey = array_filter([$relation, $relationId]);
+    
     return implode('/', $cacheKey);
   }
 }

--- a/src/Traits/Resolvable.php
+++ b/src/Traits/Resolvable.php
@@ -93,7 +93,7 @@ trait Resolvable
   /**
    * Retrieves all instances
    *
-   * @return LazyCollection
+   * @return Collection|LazyCollection Returns LazyCollection if chunking is enabled on the model.
    * @throws NotQueryableException If object not queryable
    * @throws QueryException On invalid query
    */

--- a/tests/andWhere.test.php
+++ b/tests/andWhere.test.php
@@ -91,7 +91,7 @@ final class AndWhereTest extends TestCase
       ->andWhere('id', null);
 
     $this->assertSame(
-      '(id:10000) AND ((NOT _exists_:id))',
+      '(id:10000) AND (((NOT _exists_:id) OR id:0))',
       $query->getQuery()
     );
   }
@@ -140,7 +140,7 @@ final class AndWhereTest extends TestCase
       ->andWhere('id', [1, null, 'Test string', true, [1, null, 'Test string']]);
 
     $this->assertSame(
-      '(id:10000) AND ((id:1 OR (NOT _exists_:id) OR id:"Test string" OR id:1 OR (id:1 OR (NOT _exists_:id) OR id:"Test string")))',
+      '(id:10000) AND ((id:1 OR ((NOT _exists_:id) OR id:0) OR id:"Test string" OR id:1 OR (id:1 OR ((NOT _exists_:id) OR id:0) OR id:"Test string")))',
       $query->getQuery()
     );
   }
@@ -166,7 +166,7 @@ final class AndWhereTest extends TestCase
       ->andWhere('id', '!=', null);
 
     $this->assertSame(
-      '(id:10000) AND (NOT (NOT _exists_:id))',
+      '(id:10000) AND (NOT ((NOT _exists_:id) OR id:0))',
       $query->getQuery()
     );
   }
@@ -215,7 +215,7 @@ final class AndWhereTest extends TestCase
       ->andWhere('id', '!=', [1, null, 'Test string', true, [1, null, 'Test string']]);
 
     $this->assertSame(
-      '(id:10000) AND ((NOT id:1 OR NOT (NOT _exists_:id) OR NOT id:"Test string" OR NOT id:1 OR (NOT id:1 OR NOT (NOT _exists_:id) OR NOT id:"Test string")))',
+      '(id:10000) AND ((NOT id:1 OR NOT ((NOT _exists_:id) OR id:0) OR NOT id:"Test string" OR NOT id:1 OR (NOT id:1 OR NOT ((NOT _exists_:id) OR id:0) OR NOT id:"Test string")))',
       $query->getQuery()
     );
   }

--- a/tests/cacheIdentifier.test.php
+++ b/tests/cacheIdentifier.test.php
@@ -1,0 +1,37 @@
+<?php
+
+use Netflex\Query\QueryableModel;
+
+use PHPUnit\Framework\TestCase;
+
+final class CacheIdentifierTest extends TestCase
+{
+  public function testRelation ()
+  {
+    $model = new class extends QueryableModel {
+      protected $relation = 'page';
+
+      public function proxy ($metod, ...$args) {
+        return call_user_func_array([$this, $metod], $args);
+      }
+    };
+
+    $this->assertSame('page/12345', $model->proxy('getCacheIdentifier', 12345));
+    $this->assertSame('pages', $model->proxy('getAllCacheIdentifier'));
+  }
+
+  public function testRelationId ()
+  {
+    $model = new class extends QueryableModel {
+      protected $relation = 'entry';
+      protected $relationId = 10000;
+
+      public function proxy ($metod, ...$args) {
+        return call_user_func_array([$this, $metod], $args);
+      }
+    };
+
+    $this->assertSame('entry/10000/12345', $model->proxy('getCacheIdentifier', 12345));
+    $this->assertSame('entries/10000', $model->proxy('getAllCacheIdentifier'));
+  }
+}

--- a/tests/orWhere.test.php
+++ b/tests/orWhere.test.php
@@ -83,7 +83,7 @@ final class OrWhereTest extends TestCase
       ->orWhere('id', null);
 
     $this->assertSame(
-      '(id:10000) OR ((NOT _exists_:id))',
+      '(id:10000) OR (((NOT _exists_:id) OR id:0))',
       $query->getQuery()
     );
   }
@@ -132,7 +132,7 @@ final class OrWhereTest extends TestCase
       ->orWhere('id', [1, null, 'Test string', true, [1, null, 'Test string']]);
 
     $this->assertSame(
-      '(id:10000) OR ((id:1 OR (NOT _exists_:id) OR id:"Test string" OR id:1 OR (id:1 OR (NOT _exists_:id) OR id:"Test string")))',
+      '(id:10000) OR ((id:1 OR ((NOT _exists_:id) OR id:0) OR id:"Test string" OR id:1 OR (id:1 OR ((NOT _exists_:id) OR id:0) OR id:"Test string")))',
       $query->getQuery()
     );
   }
@@ -158,7 +158,7 @@ final class OrWhereTest extends TestCase
       ->orWhere('id', '!=', null);
 
     $this->assertSame(
-      '(id:10000) OR (NOT (NOT _exists_:id))',
+      '(id:10000) OR (NOT ((NOT _exists_:id) OR id:0))',
       $query->getQuery()
     );
   }
@@ -207,7 +207,7 @@ final class OrWhereTest extends TestCase
       ->orWhere('id', '!=', [1, null, 'Test string', true, [1, null, 'Test string']]);
 
     $this->assertSame(
-      '(id:10000) OR ((NOT id:1 OR NOT (NOT _exists_:id) OR NOT id:"Test string" OR NOT id:1 OR (NOT id:1 OR NOT (NOT _exists_:id) OR NOT id:"Test string")))',
+      '(id:10000) OR ((NOT id:1 OR NOT ((NOT _exists_:id) OR id:0) OR NOT id:"Test string" OR NOT id:1 OR (NOT id:1 OR NOT ((NOT _exists_:id) OR id:0) OR NOT id:"Test string")))',
       $query->getQuery()
     );
   }

--- a/tests/where.test.php
+++ b/tests/where.test.php
@@ -65,7 +65,7 @@ final class WhereTest extends TestCase
     $query->where('id', null);
 
     $this->assertSame(
-      '(NOT _exists_:id)',
+      '((NOT _exists_:id) OR id:0)',
       $query->getQuery()
     );
   }
@@ -106,7 +106,7 @@ final class WhereTest extends TestCase
     $query->where('id', [1, null, 'Test string', true, [1, null, 'Test string']]);
 
     $this->assertSame(
-      '(id:1 OR (NOT _exists_:id) OR id:"Test string" OR id:1 OR (id:1 OR (NOT _exists_:id) OR id:"Test string"))',
+      '(id:1 OR ((NOT _exists_:id) OR id:0) OR id:"Test string" OR id:1 OR (id:1 OR ((NOT _exists_:id) OR id:0) OR id:"Test string"))',
       $query->getQuery()
     );
   }
@@ -128,7 +128,7 @@ final class WhereTest extends TestCase
     $query->where('id', '!=', null);
 
     $this->assertSame(
-      'NOT (NOT _exists_:id)',
+      'NOT ((NOT _exists_:id) OR id:0)',
       $query->getQuery()
     );
   }
@@ -169,7 +169,7 @@ final class WhereTest extends TestCase
     $query->where('id', '!=', [1, null, 'Test string', true, [1, null, 'Test string']]);
 
     $this->assertSame(
-      '(NOT id:1 OR NOT (NOT _exists_:id) OR NOT id:"Test string" OR NOT id:1 OR (NOT id:1 OR NOT (NOT _exists_:id) OR NOT id:"Test string"))',
+      '(NOT id:1 OR NOT ((NOT _exists_:id) OR id:0) OR NOT id:"Test string" OR NOT id:1 OR (NOT id:1 OR NOT ((NOT _exists_:id) OR id:0) OR NOT id:"Test string"))',
       $query->getQuery()
     );
   }

--- a/tests/whereNot.test.php
+++ b/tests/whereNot.test.php
@@ -65,7 +65,7 @@ final class WhereNotTest extends TestCase
     $query->whereNot('id', null);
 
     $this->assertSame(
-      '(NOT (NOT _exists_:id))',
+      '(NOT ((NOT _exists_:id) OR id:0))',
       $query->getQuery()
     );
   }
@@ -104,7 +104,7 @@ final class WhereNotTest extends TestCase
     $query->whereNot('id', [1, null, 'Test string', true, [1, null, 'Test string']]);
 
     $this->assertSame(
-      '(NOT (id:1 OR (NOT _exists_:id) OR id:"Test string" OR id:1 OR (id:1 OR (NOT _exists_:id) OR id:"Test string")))',
+      '(NOT (id:1 OR ((NOT _exists_:id) OR id:0) OR id:"Test string" OR id:1 OR (id:1 OR ((NOT _exists_:id) OR id:0) OR id:"Test string")))',
       $query->getQuery()
     );
   }
@@ -125,7 +125,7 @@ final class WhereNotTest extends TestCase
     $query->whereNot('id', '!=', null);
 
     $this->assertSame(
-      '(NOT NOT (NOT _exists_:id))',
+      '(NOT NOT ((NOT _exists_:id) OR id:0))',
       $query->getQuery()
     );
   }
@@ -164,7 +164,7 @@ final class WhereNotTest extends TestCase
     $query->whereNot('id', '!=', [1, null, 'Test string', true, [1, null, 'Test string']]);
 
     $this->assertSame(
-      '(NOT (NOT id:1 OR NOT (NOT _exists_:id) OR NOT id:"Test string" OR NOT id:1 OR (NOT id:1 OR NOT (NOT _exists_:id) OR NOT id:"Test string")))',
+      '(NOT (NOT id:1 OR NOT ((NOT _exists_:id) OR id:0) OR NOT id:"Test string" OR NOT id:1 OR (NOT id:1 OR NOT ((NOT _exists_:id) OR id:0) OR NOT id:"Test string")))',
       $query->getQuery()
     );
   }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our [guidelines](COMMIT_MESSAGE_GUIDELINES.md)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fixes and a couple of new features:
* NULL queries are now handles a bit different to fix a bug where in some cases 'entry' fields actually are mapped as 'text'.
* Implemented a new getAllCacheIdentifier method to provide a cache key for ::all() queries
* Added a new flag to the model that enables you to manually enabled the old chunking method without caching for ::all() queries
* Implemented a separate ::chunked method on the model to explicitly do chunking
* Refactored ::all() to allow caching

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

It might break for instances where you expect ::all() to always return a LazyCollection. The new behavior returns Collection as default, unless $useChunking is enabled on the model.
